### PR TITLE
Revert "Chore: dotenv setting"

### DIFF
--- a/backend/app/app.js
+++ b/backend/app/app.js
@@ -3,8 +3,6 @@ var express = require("express");
 var path = require("path");
 var cookieParser = require("cookie-parser");
 var logger = require("morgan");
-var dotenv = require("dotenv");
-dotenv.config();
 
 // var indexRouter = require("./src/routes/index");
 var usersRouter = require("./src/routes/users");

--- a/backend/app/src/config/db.js
+++ b/backend/app/src/config/db.js
@@ -1,10 +1,10 @@
 const mysql = require("mysql2");
 
 const db = mysql.createConnection({
-  host: process.env.DB_HOST,
-  user: process.env.DB_USER,          // mysql에 아이디를 넣는다.
-  password: process.env.DB_PASSWORD,  // mysql의 비밀번호를 넣는다.
-  database: process.env.DB_DATABASE,  //위에서 만든 데이터베이스의 이름을 넣는다.
+  host: "localhost",
+  user: "root", // mysql에 아이디를 넣는다.
+  password: "work", // mysql의 비밀번호를 넣는다.
+  database: "frdg", //위에서 만든 데이터베이스의 이름을 넣는다.
 });
 
 db.connect();


### PR DESCRIPTION
Reverts alexization/foodycode#45

사유: 로컬에서 db비번 변경의 번거로움이 있으나 후에 있을 여러번의 배포 테스트에서 aws 가상 컴퓨터인 ec2를 만들 때 db 비밀번호를 갈아끼는 작업에 번거로움으로 .env파일을 생성하지 않고 db.js파일에 비밀번호를 work로 계속 고정함.
