### PR TITLE
Feat/signup alg back

### DIFF
--- a/backend/app/src/models/AlgStorage.js
+++ b/backend/app/src/models/AlgStorage.js
@@ -25,5 +25,6 @@ class AlgStorage{
     });
   }
 
+
 }
 module.exports = AlgStorage;

--- a/backend/app/src/models/MenuStroage.js
+++ b/backend/app/src/models/MenuStroage.js
@@ -1,4 +1,4 @@
-db = require('../config/db');
+const db = require('../config/db');
 
 class MenuStorage {
   static getMenuInfo(rest_name) {

--- a/backend/app/src/models/User.js
+++ b/backend/app/src/models/User.js
@@ -29,6 +29,7 @@ class User{
     async register(){
         const client = this.body;
         console.log(client.password);
+        console.log(client);
         try {
         const response = await UserStorage.save(client);
         return response;

--- a/backend/app/src/models/UserStorage.js
+++ b/backend/app/src/models/UserStorage.js
@@ -29,9 +29,21 @@ class UserStorage{
     static async save(userInfo){
         return new Promise((resolve,reject) => {
             // const query = "INSERT INTO users(uid,name,psword) VALUES(?,?,?);";
-            //db.query(query,[userInfo.uid,userInfo.name,userInfo.psword],
-            const query = "INSERT INTO users(uid,psword,name,age,gen,country,email) VALUES(?,?,'3','3','3','3','3');";
-            
+            // db.query(query,[userInfo.uid,userInfo.name,userInfo.psword],
+            const info_query = "INSERT INTO users(uid,psword,name,age,gen,country,email) VALUES(?,?,'3','3','3','3','3');";
+        
+
+            let insertValues = '';
+            // 유저 알러지 정보가 하나라도 선택되어 있을때만 쿼리를 생성
+            if (userInfo.arr_algid.length > 0) {
+                insertValues = arr_algid.map(algid => `(${algid}, (SELECT id FROM users WHERE uid = '${userInfo.uid}'))`).join(', ');
+            }
+
+            // insertValues가 생성될때만 alg_Query를 생성
+            const alg_Query = insertValues ? `INSERT INTO useralgs (algid, uid) VALUES    ${insertValues};` : '';
+
+            const query = `${info_query}\n${alg_Query}`;
+
             db.query(query,[userInfo.uid,userInfo.password],(err)=>{
                 if(err) throw reject(`${err}`);
                 resolve({success:true});
@@ -40,22 +52,6 @@ class UserStorage{
         
     }
 
-    
-  static saveUserAlg(user_uid , arr_algid){
-    return new Promise((resolve,reject)=>{
-        const arr = arr_algid;
-        const uid = user_uid;
-    
-        const insertValues = arr.map(algid => `(${algid}, (SELECT id FROM users WHERE uid = '${uid}'))`).join(', ');
-        
-        const query = `INSERT INTO useralgs (algid, uid) VALUES ${insertValues};`;
-            db.query(query,[],(err,data)=>{
-                if (err) throw reject(`${err}`);
-                resolve({success:true});
-      });
-    });
- 
-  }
 
 
 

--- a/backend/app/src/models/UserStorage.js
+++ b/backend/app/src/models/UserStorage.js
@@ -2,6 +2,7 @@
 
 const db = require('../config/db');
 
+
 //class명은 파일이름과 동일한게 좋음
 class UserStorage{
     
@@ -30,6 +31,7 @@ class UserStorage{
             // const query = "INSERT INTO users(uid,name,psword) VALUES(?,?,?);";
             //db.query(query,[userInfo.uid,userInfo.name,userInfo.psword],
             const query = "INSERT INTO users(uid,psword,name,age,gen,country,email) VALUES(?,?,'3','3','3','3','3');";
+            
             db.query(query,[userInfo.uid,userInfo.password],(err)=>{
                 if(err) throw reject(`${err}`);
                 resolve({success:true});
@@ -37,6 +39,23 @@ class UserStorage{
         });
         
     }
+
+    
+  static saveUserAlg(user_uid , arr_algid){
+    return new Promise((resolve,reject)=>{
+        const arr = arr_algid;
+        const uid = user_uid;
+    
+        const insertValues = arr.map(algid => `(${algid}, (SELECT id FROM users WHERE uid = '${uid}'))`).join(', ');
+        
+        const query = `INSERT INTO useralgs (algid, uid) VALUES ${insertValues};`;
+            db.query(query,[],(err,data)=>{
+                if (err) throw reject(`${err}`);
+                resolve({success:true});
+      });
+    });
+ 
+  }
 
 
 

--- a/backend/app/src/models/UserStorage.js
+++ b/backend/app/src/models/UserStorage.js
@@ -28,26 +28,33 @@ class UserStorage{
 
     static async save(userInfo){
         return new Promise((resolve,reject) => {
-            // const query = "INSERT INTO users(uid,name,psword) VALUES(?,?,?);";
-            // db.query(query,[userInfo.uid,userInfo.name,userInfo.psword],
+            
             const info_query = "INSERT INTO users(uid,psword,name,age,gen,country,email) VALUES(?,?,'3','3','3','3','3');";
         
+            db.query(info_query,[userInfo.uid,userInfo.password],(err)=>{
+                console.log(info_query);
+                if(err) throw reject(`${err}`);
 
+                //resolve먼저 해버리면 알러지 전에 반환해버리니깐 나눠서
+                //resolve({success:true});
+            });
+
+            //inservalues에 빈문자열 할당, if문 후 쿼리 생성
             let insertValues = '';
+
             // 유저 알러지 정보가 하나라도 선택되어 있을때만 쿼리를 생성
             if (userInfo.arr_algid.length > 0) {
-                insertValues = arr_algid.map(algid => `(${algid}, (SELECT id FROM users WHERE uid = '${userInfo.uid}'))`).join(', ');
+                insertValues = userInfo.arr_algid.map(algid => `(${algid}, (SELECT id FROM users WHERE uid = '${userInfo.uid}'))`).join(', ');
+        
+                // insertValues가 생성될때만 alg_Query를 생성  (혹시모를 오류)
+                const alg_query = insertValues ? `INSERT INTO useralgs (algid, uid) VALUES    ${insertValues};` : '';
+
+                db.query(alg_query,[userInfo.uid,userInfo.password],(err)=>{
+                    if(err) throw reject(`${err}`);
+                    resolve({success:true});
+                });
+
             }
-
-            // insertValues가 생성될때만 alg_Query를 생성
-            const alg_Query = insertValues ? `INSERT INTO useralgs (algid, uid) VALUES    ${insertValues};` : '';
-
-            const query = `${info_query}\n${alg_Query}`;
-
-            db.query(query,[userInfo.uid,userInfo.password],(err)=>{
-                if(err) throw reject(`${err}`);
-                resolve({success:true});
-            });
         });
         
     }

--- a/backend/app/src/models/test.js
+++ b/backend/app/src/models/test.js
@@ -1,0 +1,10 @@
+const arr_algid = [];
+const uid = 'leo1313';
+
+const insertValues = arr_algid.map(algid => `(${algid}, (SELECT id FROM users WHERE uid = '${uid}'))`).join(', ');
+
+const sqlQuery = `INSERT INTO useralgs (algid, uid)
+VALUES
+    ${insertValues};`;
+
+console.log(sqlQuery);

--- a/backend/app/src/models/test.js
+++ b/backend/app/src/models/test.js
@@ -1,10 +1,52 @@
-const arr_algid = [];
-const uid = 'leo1313';
+// const arr_algid = [1];
+// const uid = 'leo1313';
 
-const insertValues = arr_algid.map(algid => `(${algid}, (SELECT id FROM users WHERE uid = '${uid}'))`).join(', ');
+// const insertValues = ''; // 빈 문자열로 초기화
 
-const sqlQuery = `INSERT INTO useralgs (algid, uid)
-VALUES
-    ${insertValues};`;
+// if (arr_algid.length > 0) {
+//     insertValues = arr_algid.map(algid => `(${algid}, (SELECT id FROM users WHERE uid = '${uid}'))`).join(', ');
+// }
 
-console.log(sqlQuery);
+// const sqlQuery = insertValues ? `INSERT INTO useralgs (algid, uid)\nVALUES\n    ${insertValues};` : '';
+
+// console.log(sqlQuery);
+
+
+// const userInfo='sdfsdf';
+// const arr_algid=[1];
+
+// const info_query = "INSERT INTO users(uid,psword,name,age,gen,country,email) VALUES(?,?,'3','3','3','3','3');";
+        
+
+// const insertValues = '';
+//             //유저 알러지 정보가 하나라도 선택되어 있을때만 테이블에 저장
+// if (arr_algid.length > 0) {
+//     insertValues = arr_algid.map(algid => `(${algid}, (SELECT id FROM users WHERE uid = '${userInfo}'))`).join(', ');
+// }
+
+
+
+
+
+// const alg_Query = insertValues ? `INSERT INTO useralgs (algid, uid) VALUES    ${insertValues};` : '';
+            
+            
+// const query = `${info_query}\n${alg_Query}`;
+
+
+const userInfo = "sdfsdf";
+const arr_algid = [1];
+
+const info_query = "INSERT INTO users(uid, psword, name, age, gen, country, email) VALUES (?, ?, '3', '3', '3', '3', '3');";
+
+let insertValues = '';
+// 유저 알러지 정보가 하나라도 선택되어 있을 때만 테이블에 저장
+if (arr_algid.length > 0) {
+    insertValues = arr_algid.map(algid => `(${algid}, (SELECT id FROM users WHERE uid = ?))`).join(', ');
+}
+
+const alg_Query = insertValues ? `INSERT INTO useralgs (algid, uid) VALUES ${insertValues};` : '';
+
+const query = `${info_query}\n${alg_Query}`;
+
+console.log(query);


### PR DESCRIPTION
기존 회원가입 API
- 회원가입을 할때 유저 id,psword 만 들어감

이번 pull에서 바뀐점
- body에서 arr_algid라는 이름의 배열을 받으면 DB에 저장해줌 
- 빈리스트 [] 이면 알아서 아무것도 입력 안하니 따로 none으로 명시해줄 필요는 없습니다!