### PR TITLE
feat: HomeUserInfo.vue allergy tag 스크롤 UI 개선

### DIFF
--- a/frontend/src/components/HomeUserInfo.vue
+++ b/frontend/src/components/HomeUserInfo.vue
@@ -45,18 +45,18 @@ export default {
 }
 
 .user-info-wrapper {
-  position: absolute;
   display: flex;
   flex-direction: column;
   width: 100%;
-  height: 110px;
+  height: 110px;  
+  margin: 0px;
   background: #ffffff;
 }
 
 .user-name-box {
   display: inline-flex;
   justify-content: flex-start;
-  width: 360px;
+  width: 88%;
   height: 55px;
   margin: 0px auto;
 }
@@ -83,27 +83,28 @@ export default {
   display: flex;
   justify-content: flex-start;
   overflow-x: auto;
-  width: 360px;
+  width: 100%;
   height: 55px;
   margin: 0px auto;
-  padding: 0px 10px 10px;
+  padding: 0px 6% 10px;
 }
 
 .alg-tag {
   position: relative;  
   height: 35px;
   padding: 4px 10px 0px;
-  border: 1px solid #1c9181;
-  border-radius: 10px;
-  margin-right: 10px;
-  background: #1c9181;
-  color: #ffffff;
+  border: none;
+  border-radius: 15px;
+  margin: 0px 2.5px;
+  background: rgba(28, 145, 129, .1);
+  color: rgba(28, 145, 129, 1);
   letter-spacing: 1.2px;
   font: 400 16px "Noto Sans", sans-serif;
   text-align: center;
 }
 
-::-webkit-scrollbar {
-  display: none;
+.user-alg-box::-webkit-scrollbar {
+  display: none;   
 }
+
 </style>


### PR DESCRIPTION
frontend
HomeUserInfo.vue 컴포넌트에서 allergy tag에 스크롤 UI 개선 및 반응형 기능 추가
<br/>
◆ 홈화면에서 유저 알러지 태그들이 스크롤 되는지 유저가 모를것 같다고 페이지네이션 추가에 대한 사항

여러 앱을 참고해봤는데 3가지 방법을 생각했어요.

1. 페이지네이션으로 화살표 버튼을 넣어 스크롤 애니메이션을 추가하는 방법
- 가능은 하지만 이 방법은 주로 안의 요소들이 같은 너비를 가질 때 사용함.
- 너비가 서로 많이 다르다면 페이지네이션 애니메이션 추가 시 몇 개 만큼 이동이 되도록 기준을 잡기가 어려움.
- 버튼 크기 만큼 보여줄 수 있는 태그 정보 수가 줄어듬.

     ⇒  이 방법은 안쓰는 것이 좋을 것 같다.

2. 태그들이 많다면 스크롤 바를 축소 형식으로 보여주어 스크롤 정보를 유저에게 알려주는 방법
 - 번개장터의 메인 화면에 스크롤이 이 방법을 씀.
 - 스크롤 바 영역 축소가 웹에서 불가
 - 스크롤바 커스텀은 가능하나 웹에서만 가능하고 모바일 브라우저에서는 적용이 안되는 문제가 있음.
 - 스크롤이 필요할 때 스크롤바를 항상 보여줄 수 있도록 하는 것이 모바일에서 적용이 안되는 문제가 있음.

     ⇒ 이 방법은 구현이 어렵다.

3. 스크롤을 전체 너비로 하고 스크롤바가 보이지 않도록하고 padding으로 스타일을 맞추는 방법.
 - 배민, 번개장터 등 많은 앱들이 가변적인 태그 스크롤 방식에 대해 이 방법을 쓰는 것 같음. 
 - 유저에게 보여줄 수 있는 정보량이 많음.
 - 태그가 화면에 짤리지 않아 유저가 스크롤이 없다고 생각하는 경우는 극히 드뭄.
 - 유저 본인이 알러지 선택을 했으므로 누락된 정보에 대해서 어느정도 인지하고 있어 스크롤이 있다고 생각하기 쉬움.

     **⇒ 이 방법이 가장 유력.** 
<br/>
일단은 3번째 방법을 적용

이후에 유저의 allergy 정보를 [나의 필터링카드] 로 지갑처럼 암호화하여 보호하도록 할 예정 - 현준

이슈 번호:  #68